### PR TITLE
added lodash.throttle to packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "hapi": "^8.6.1",
     "johnny-five": "^0.8.43",
     "jsx-loader": "^0.13.2",
+    "lodash.throttle": "^4.0.1",
     "node-libs-browser": "^0.5.2",
     "react": "^0.13.3",
     "reflux": "^0.2.8",


### PR DESCRIPTION
Hey, this is an awesome plugin, thanks for letting me know about it!

I did `npm install` then `grunt` to set it up. When I ran the examples, I got the error:

```
Error: Cannot find module 'lodash.throttle'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (...blah blah.../browse-io/lib/server/index.js:3:16)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```

I did `npm install lodash.throttle --save` and that fixed the problem. Not sure about how lodash dependencies work so this might not be the best fix.
